### PR TITLE
Migrate to anyhow errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ axum = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 aws-sdk-s3 = "0.36.0"
-thiserror = "1"
+anyhow = "1"
 rkyv = { version = "0.7", default-features = false, features = ["alloc"] }
 async-stream = "0.3"
 uuid = { version = "1", features = ["v4"] }

--- a/src/api.rs
+++ b/src/api.rs
@@ -4,6 +4,7 @@ use axum::extract::State;
 use std::sync::Arc;
 use crate::wal::WalAppender;
 use crate::models::VectorRecord;
+use anyhow::Result;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -16,12 +17,12 @@ pub fn app(state: AppState) -> Router {
         .with_state(state)
 }
 
-pub async fn run_server(addr: std::net::SocketAddr, state: AppState) {
+pub async fn run_server(addr: std::net::SocketAddr, state: AppState) -> Result<()> {
     let app = app(state);
     axum::Server::bind(&addr)
         .serve(app.into_make_service())
-        .await
-        .expect("server failed");
+        .await?;
+    Ok(())
 }
 
 async fn put_document(State(state): State<AppState>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,10 @@
 use recallmon::{run_server, api::AppState, wal::WalAppender};
 use std::sync::Arc;
 use aws_sdk_s3::Client;
+use anyhow::Result;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let config = aws_config::load_from_env().await;
@@ -14,6 +15,7 @@ async fn main() {
     };
 
     let state = AppState { wal: Arc::new(wal) };
-    let addr = "0.0.0.0:3000".parse().unwrap();
-    run_server(addr, state).await;
+    let addr = "0.0.0.0:3000".parse()?;
+    run_server(addr, state).await?;
+    Ok(())
 }

--- a/src/wal.rs
+++ b/src/wal.rs
@@ -1,12 +1,6 @@
 use aws_sdk_s3::{Client, types::ByteStream};
-use thiserror::Error;
+use anyhow::Result;
 use crate::models::VectorRecord;
-
-#[derive(Error, Debug)]
-pub enum WalError {
-    #[error("s3 error: {0}")]
-    S3(#[from] aws_sdk_s3::Error),
-}
 
 #[derive(Clone)]
 pub struct WalAppender {
@@ -15,8 +9,8 @@ pub struct WalAppender {
 }
 
 impl WalAppender {
-    pub async fn append(&self, rec: &VectorRecord) -> Result<(), WalError> {
-        let data = serde_json::to_vec(rec).expect("serialize");
+    pub async fn append(&self, rec: &VectorRecord) -> Result<()> {
+        let data = serde_json::to_vec(rec)?;
         let body = ByteStream::from(data);
         let key = format!("wal/{}.wal", uuid::Uuid::new_v4());
         self.client


### PR DESCRIPTION
## Summary
- add `anyhow` dependency
- use `anyhow::Result` in WAL, API server, and main

## Testing
- `cargo check` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fc2dab2e483288fa8498fcd5ab1a6