### PR TITLE
Docs update for planner

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,20 @@ When the working set is cached it performs like an in-memory system; when it is 
 | --------------------------------- | --------------------------------------------------------------------------------- |
 | **Object-storage-native LSM WAL** | Infinite, cheap, 11 x durability; no replication of SSDs required.                |
 | **Write-through NVMe/RAM cache**  | Warm queries in ≈ 10-20 ms while keeping operating cost low.                      |
-| **Centroid-based ANN (SPFresh)**  | Minimises round-trips on cold reads and supports incremental in-place updates.    |
+| **Centroid-based ANN** | Minimises round-trips on cold reads and supports incremental in-place updates. |
 | **Compute/compute separation**    | Query nodes stay lightweight; heavy index builds run on ephemeral “indexer” pods. |
 | **Multi-tenant by prefix**        | Millions of namespaces, each independently cached / evicted.                      |
 
+
+## Components
+Detailed documentation for each subsystem lives under the [`docs/`](./docs) directory:
+
+- [Write-Ahead Log](docs/wal/README.md)
+- [SSTables](docs/sstable/README.md)
+- [ANN blocks](docs/ann-block/README.md)
+- [Compaction service](docs/compaction/README.md)
+- [Caching tiers](docs/caching/README.md)
+- [Query executor](docs/query-executor/README.md)
+- [BM25 scoring](docs/bm25/README.md)
+- [Consistency model](docs/consistency/README.md)
+- [Transactions](docs/transactions/README.md)

--- a/docs/ann-block/README.md
+++ b/docs/ann-block/README.md
@@ -1,0 +1,26 @@
+Purpose
+Houses a centroid-partitioned HNSW index for ±1 million vectors.
+
+## Layout (.ann)
+```
+HEADER          –  1 KiB (dims, metric, M, ef)
+CENTROIDS       –  C * 16 KiB  (float32[dim] + child-count)
+VEC-HEAP        –  contiguous, quantised (f16 or pq-8-bit)
+NEIGHBOR LISTS  –  var-int adjacency
+FOOTER (CRC32)
+```
+
+## Build Pipeline
+1. K-means++ (mini-batch) → centroids (`C=√N`).
+2. Assign vectors → shards, quantise.
+3. Build per-shard HNSW (`M=16`, `ef_con=200`).
+4. Spill to S3 with `X-Amz-Tagging=ann`.
+
+## Query Flow
+1. load centroid slab (vector) – 1 GET
+2. select top-K shards (dot/cosine) – CPU
+3. bulk fetch shard HNSWs in parallel – ≤K GETs
+4. intra-shard HNSW search (`ef_runtime`) – CPU
+
+### Hot-Patch Updates
+Small inserts go to a mutable RAM-graph flushed into the next compaction round.

--- a/docs/bm25/README.md
+++ b/docs/bm25/README.md
@@ -1,0 +1,14 @@
+## Parameters
+- `k1 = 1.2`
+- `b = 0.75`
+- Field-level boosts configurable in `schema.yml`.
+
+### Indexing
+Classic inverted index (Roaring + positions) lives in the same SSTable:
+- term-dict → postings (delta-varint)
+- positions zipped with SIMD-BP128
+
+### Query-time
+- Parse, de-stem, stop-filter.
+- Intersect postings (AND) / union (OR).
+- Accumulate BM25, spill into top-K heap shared with ANN results.

--- a/docs/caching/README.md
+++ b/docs/caching/README.md
@@ -1,0 +1,13 @@
+## Tiers
+| Layer | Medium      | Hit µ-lat   | Eviction      |
+|------|-------------|-------------|---------------|
+| L0   | heap (arena) | 0.1–2 µs   | CLOCK-pro     |
+| L1   | NVMe SSD (ZNS) | 25–150 µs | LFU-segmented |
+| L2   | S3 / GCS    | 100–400 ms | N/A           |
+
+### Admission
+- Tiny WAL pages always L0.
+- SST/ANN blocks: admit on 2nd hit (TinyLFU).
+
+### Metadata
+`cache_index` TinyHash keyed by S3 ETag to detect stale objects.

--- a/docs/compaction/README.md
+++ b/docs/compaction/README.md
@@ -1,0 +1,16 @@
+Role
+Maintains LSM health; merges WAL-derived fragments into leveled SSTables and stitches new ANN blocks.
+
+## Scheduler
+Runs on indexer nodes only. Priority queue by `(level, age, tombstone-ratio, read-heat)`.
+
+## Compaction Types
+| Type   | Trigger             | Effect              |
+|-------|--------------------|---------------------|
+| Minor | `wal_size > 512 MiB` | `WAL → L0 SST + ΔANN` |
+| Level | `ΣLk > 10× target` | `Lk ⨁ Lk→1`          |
+| Garbage | `tombstone > 20 %` | rewrite minus deletes |
+
+## Throttling
+- Cap total S3 PUTs per tenant (`--max_put_mb=200`).
+- Yield to query nodes if NVMe IOPs > 80&nbsp;%.

--- a/docs/consistency/README.md
+++ b/docs/consistency/README.md
@@ -1,0 +1,5 @@
+Read-Your-Own-Write (RYOW) for single client.
+
+Linearizable WAL appends: `(If-None-Match)` + cross-AZ submit + quorum-etag check.
+
+Queries default to bounded-staleness ≤1&nbsp;s; caller may request `staleness=0` (forces list-prefix poll).

--- a/docs/query-executor/README.md
+++ b/docs/query-executor/README.md
@@ -1,0 +1,28 @@
+## Pipeline
+```
+HTTP/gRPC
+  └─→ Gateway
+        • auth / ratelimit
+        • resolves namespace
+        • consistent-hash to QE-node
+            └─ Query Executor
+                 1) parse AST
+                 2) pushdown (filters → LSM, KNN → ANN)
+                 3) fetch WAL tail
+                 4) merge iterators (SST + WAL)
+                 5) scorer:
+                       • BM25
+                       • vector_score (if KNN)
+                 6) top-k heap → JSON/Arrow
+```
+
+### Concurrency Model
+- Each QE uses tokio tasks bound to NUMA cores.
+- I/O via `io_uring`; budgeted 4k ops / core.
+
+
+### API usage
+Clients interact through a JSON/HTTP API to insert vectors and issue queries. No SQL interface is provided.
+
+### Planner
+A simple planner chooses when to apply lexical filters relative to the ANN search and sets centroid distance limits to balance recall and latency.

--- a/docs/sstable/README.md
+++ b/docs/sstable/README.md
@@ -1,0 +1,23 @@
+Purpose
+Immutable, sorted chunk emitted by the ingest pipeline and merged by compaction. All point and range look-ups hit SSTables first, then the WAL tail.
+
+## Physical Layout
+```
+| data blocks … | 4-KiB   |
+| restart table | 4-KiB   |
+| footer        | 128 B   |
+```
+Data block: 64&nbsp;KiB, Snappy-compressed key+value pairs with prefix compression.
+Restart table: `u32` offsets every N=16 keys for `O(log n)` binary search.
+Footer: magic, CRC, absolute offset of restart table.
+
+### On-Disk Key
+`tenant-id | table-id | primary-key | logical-ts`
+
+## APIs
+- `iterator.seek(key)` – binary search restart table; scans block in-memory.
+- `meta()` – returns min/max PK, tombstone flag, bloom-filter.
+
+### Bloom Filter
+- 10 bits / key → <1&nbsp;% false positives.
+- Stored as raw bitset in file trailer.

--- a/docs/transactions/README.md
+++ b/docs/transactions/README.md
@@ -1,0 +1,18 @@
+## Scope
+Single-key idempotent puts & deletes (exactly what we write to the WAL). Multi-row / multi-table ACID is out-of-scope; use app-side sagas.
+
+## Call Flow
+```
+BEGIN
+PUT /txn/prepare  {batch…}   -> 202 + txid
+… client retries allowed …
+PUT /txn/commit?txid=123     -> 200 OK
+```
+prepare stage buffered in DynamoDB sticky to tenant.
+commit stage writes atomically into next WAL segment and waits for `⟂sealed` ack.
+If no commit within TTL (30 s) → automatic rollback.
+
+## Guarantees
+- Exactly-once append.
+- RYOW for same txid.
+- Detected-duplicate idempotency via txn-table.

--- a/docs/wal/README.md
+++ b/docs/wal/README.md
@@ -1,0 +1,32 @@
+Purpose
+The Write-Ahead Log (WAL) is the source-of-truth event stream. Every mutation is appended here before it becomes visible anywhere else.
+
+## File Layout
+| Byte Range | Field        | Notes                             |
+|-----------:|--------------|-----------------------------------|
+| 0-7        | u64 magic    | `0x57414C3032` ("WAL02")          |
+| 8-15       | u64 txn-id   | Monotonic, globally unique        |
+| 16-23      | u64 timestamp-µs | Physical clock               |
+| 24-31      | u64 checksum | xxHash64 of payload               |
+| 32-…       | CBOR payload | Insert / Delete / Upsert JSON doc |
+
+One file per WAL segment. Each segment is sized to 256&nbsp;MiB (configurable) and named `0000000000000000.wal`, `…0001.wal`, …
+
+## Operations
+| API                       | Action                                                             |
+|---------------------------|--------------------------------------------------------------------|
+| `append(bytes entry)`     | Atomically PUTs new object to S3: `wal/$seg/$offset` with `If-None-Match:"*"` |
+| `seal(seg#)`              | Writes zero-byte `wal/$seg/⟂sealed` object.                       |
+
+## Crash-Recovery
+1. List objects under current segment.
+2. Replay in offset order, verifying checksum.
+3. Stop at first corrupt / missing gap.
+
+## Metrics
+- `wal_put_seconds` (histogram)
+- `wal_replication_lag` (bytes behind compactor)
+
+## Tuning Knobs
+- `SEG_SIZE` – 64&nbsp;MiB – 1&nbsp;GiB
+- `FLUSH_INTERVAL_MS` – group-commit window


### PR DESCRIPTION
## Summary
- drop SPFresh docs and mentions
- describe HTTP API usage
- outline simple planner instead of SQL

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_683fc7f32b8883288b1371d940325f24